### PR TITLE
Add api header to include js files in render

### DIFF
--- a/src/_quarto.yml
+++ b/src/_quarto.yml
@@ -57,6 +57,3 @@ format:
   html:
     theme: cosmo
     toc: true
-
-
-

--- a/src/api-authentication-and-jobs.qmd
+++ b/src/api-authentication-and-jobs.qmd
@@ -1,5 +1,10 @@
 ---
 title: Authentication and Jobs 
+format:
+  html:
+    code-fold: true
+    include-in-header: 
+      - api-header.html
 ---
 
 Here’s a quick overview of our jobs system, and steps to access auth credentials for our APIs. Find more details on our endpoints at [Project](./api-project.qmd) and [PoET](./api-poet.qmd), serving our core and generative workflows respectively.
@@ -69,7 +74,6 @@ print("Generated MSA: ", response.text)
 ## Endpoints
 
 ```{=html}
-  <script src="https://unpkg.com/swagger-ui-dist@5.1/swagger-ui-bundle.js"></script>
   <script type="module">
     import getSwaggerJson from './utils/getSwaggerJson.js'
     import addSwaggerEndpointsToTOC from './utils/addSwaggerEndpointsToTOC.js';

--- a/src/api-embeddings.qmd
+++ b/src/api-embeddings.qmd
@@ -3,6 +3,8 @@ title: Embeddings
 format:
   html:
     code-fold: true
+    include-in-header: 
+      - api-header.html
 ---
 
 The Embeddings API provided by OpenProtein.ai allows you to generate state-of-the-art protein sequence embeddings from both proprietary and open source models. <br/>\nYou can list the available models with `/embeddings/models` and view a model summary (including output dimensions, citations and more) with `/embeddings/model/metadata`. <br/>
@@ -20,7 +22,6 @@ These models are based on the ESM2 language model, with different version having
 ## Endpoints
 
 ```{=html}
-<script src="https://unpkg.com/swagger-ui-dist@5.1/swagger-ui-bundle.js"></script>
 <script type="module">
   import addSwaggerEndpointsToTOC from './utils/addSwaggerEndpointsToTOC.js';
   window.onload = function() {

--- a/src/api-header.html
+++ b/src/api-header.html
@@ -1,0 +1,3 @@
+<script src="https://unpkg.com/swagger-ui-dist@5.1/swagger-ui-bundle.js"></script>
+<script type="module" src="./utils/getSwaggerJson.js"></script>
+<script type="module" src="./utils/addSwaggerEndpointsToTOC.js"></script>  

--- a/src/api-poet.qmd
+++ b/src/api-poet.qmd
@@ -3,6 +3,8 @@ title: PoET
 format:
   html:
     code-fold: true
+    include-in-header: 
+      - api-header.html
 ---
 
 Protein Evolutionary Transformer (`PoET`) is a machine learning model that generates and identifies protein sequence variants with improved function and stability. PoET requires a prompt, (ie. a set of sequences representing the target protein sequence distribution). This will commonly be an evolutionary context prompt in the form of filtered MSAs (Align). But `PoET` can accept any collection of sequences!
@@ -17,11 +19,13 @@ Endpoints to call our generative `PoET` model for de novo generation of proteins
 ## Endpoints
 
 
+
+
 ```{=html}
-  <script src="https://unpkg.com/swagger-ui-dist@5.1/swagger-ui-bundle.js"></script>
   <script type="module">
-    import getSwaggerJson from './utils/getSwaggerJson.js';
-    import addSwaggerEndpointsToTOC from './utils/addSwaggerEndpointsToTOC.js';
+    import getSwaggerJson from "./utils/getSwaggerJson.js"
+    import addSwaggerEndpointsToTOC from './utils/addSwaggerEndpointsToTOC.js'
+
     window.onload = async function() {
       // get swagerSpecs manipulated 
       const swagerSpecs = await getSwaggerJson('poet');

--- a/src/api-project.qmd
+++ b/src/api-project.qmd
@@ -3,6 +3,8 @@ title: Project
 format:
   html:
     code-fold: true
+    include-in-header: 
+      - api-header.html
 ---
 
 This section provides detailed information about the endpoints available within the 'Project' module. These endpoints enable users to leverage the functionalities offered by the module and perform various actions programmatically. Using these endpoints, access features like train a model, make predictions, design sequences based on properties and check on job statuses.
@@ -33,7 +35,6 @@ A trained model is required before design endpoints can be utilized.
 ## Endpoints
 
 ```{=html}
-  <script src="https://unpkg.com/swagger-ui-dist@5.1/swagger-ui-bundle.js"></script>
   <script type="module">
     import getSwaggerJson from './utils/getSwaggerJson.js';
     import addSwaggerEndpointsToTOC from './utils/addSwaggerEndpointsToTOC.js';


### PR DESCRIPTION
Bug: build was not including the js files
Solution: 
- I added the header file in include-in-header
- Also included <script src="https://unpkg.com/swagger-ui-dist@5.1/swagger-ui-bundle.js"></script> as suggested in #25 