### PR TITLE
fix: resolve stale sphinx doc links and orphaned page

### DIFF
--- a/source/python-api/foundation-models/index.rst
+++ b/source/python-api/foundation-models/index.rst
@@ -31,7 +31,6 @@ Get started using foundation models
 * `SVD embeddings <./SVD-embeddings.rst>`_
 * `Model metadata <./model-metadata.rst>`_
 * `Logits <./logits.rst>`_
-* `Basic inference endpoints <./basic-inference-endpoints.rst>`_
 * `Attention maps <./attention-maps.rst>`_
 * `Using AbLang2 <./Using_AbLang2.ipynb>`_
 
@@ -42,7 +41,6 @@ Get started using foundation models
     :hidden:
     :maxdepth: 2
 
-    Basic inference <basic-inference>
     Model metadata <model-metadata>
     SVD and embeddings <SVD-embeddings>
     Logits <logits>

--- a/source/resources/tutorials-examples.rst
+++ b/source/resources/tutorials-examples.rst
@@ -223,7 +223,6 @@ Embeddings
                         <ul>
                             <li><a href="../python-api/foundation-models/SVD-embeddings.html">SVD embeddings</a></li>
                             <li><a href="../python-api/foundation-models/attention-maps.html">Attention maps</a></li>
-                            <li><a href="../python-api/foundation-models/basic-inference-endpoints.html">Basic inference endpoints</a></li>
                             <li><a href="../python-api/foundation-models/model-metadata.html">Model metadata</a></li>
                             <li><a href="../python-api/foundation-models/logits.html">Logits</a></li>
                         </ul>

--- a/source/web-app/opmodels/index.rst
+++ b/source/web-app/opmodels/index.rst
@@ -23,6 +23,7 @@ Learn more and get started with our tutorials
 - `Using reference sequences <./reference-sequence.rst>`_
 - `Navigating your projects <./navigating-your-projects.rst>`_
 - `Visualizing your data <./visualization.rst>`_
+- `Protein language models and embeddings <./protein-language-models-embeddings.rst>`_
 - `Model training and evaluation <./model-train-evaluate.rst>`_
 - `Substitution analysis with OP Models <./sub-analysis.rst>`_
 - `Designing sequences <./design.rst>`_
@@ -38,6 +39,7 @@ Learn more and get started with our tutorials
   reference-sequence
   navigating-your-projects
   Visualization <visualization>
+  Protein language models and embeddings <protein-language-models-embeddings>
   Model training and evaluation <model-train-evaluate>
   Substitution analysis with OP Models <sub-analysis>
   Design <design>

--- a/source/web-app/poet/generate-sequences.rst
+++ b/source/web-app/poet/generate-sequences.rst
@@ -117,7 +117,7 @@ A 400 (Bad request) error code may be due to the following:
        - a top_p > 1
        - a non-valid amino acid
        - Maximum similarity < minimum similarity
-       If necessary, refer to the article on `sampling parameters <./prompts.rst#prompt-sampling-definitions>`_.
+       If necessary, refer to the article on `sampling parameters <./prompts.rst#prompt-sampling-parameters>`_.
    * - Invalid MSA (not aligned, etc)
      - - Make sure your MSAs are aligned and rebuild MSA if necessary.
        - If you have uploaded pre-computed MSA, confirm that formatting is correct and sequences are of equal length (use gap tokens “-”).

--- a/source/web-app/poet/rank-sequences.rst
+++ b/source/web-app/poet/rank-sequences.rst
@@ -71,7 +71,7 @@ A 400 (Bad request) error code may be due to the following:
        - a top_p > 1
        - a non-valid amino acid
        - Maximum similarity < minimum similarity
-       If necessary, refer to the article on `sampling parameters <./prompts.rst#prompt-sampling-definitions>`_.
+       If necessary, refer to the article on `sampling parameters <./prompts.rst#prompt-sampling-parameters>`_.
    * - Invalid MSA (not aligned, etc)
      - - Make sure your MSAs are aligned and rebuild MSA if necessary.
        - If you have uploaded pre-computed MSA, confirm that formatting is correct and sequences are of equal length (use gap tokens “-”).

--- a/source/web-app/poet/substitution-analysis.rst
+++ b/source/web-app/poet/substitution-analysis.rst
@@ -51,7 +51,7 @@ A 400 (Bad request) error code may be due to the following:
        - a top_p>1
        - a non-valid amino acid
        - Maximum similarity < minimum similarity
-       If necessary, refer to the article on `sampling parameters <./prompts.rst#prompt-sampling-definitions>`_.
+       If necessary, refer to the article on `sampling parameters <./prompts.rst#prompt-sampling-parameters>`_.
    * - Invalid MSA (not aligned, etc)
      - - Make sure your MSAs are aligned and rebuild MSA if necessary.
        - If you have uploaded pre-computed MSA, confirm that formatting is correct and sequences are of equal length (use gap tokens “-”).


### PR DESCRIPTION
## What

Cleans up three pre-existing broken-link / orphaned-page issues in the docs (surfaced while investigating a strict-build gate):

- **Dead `basic-inference-endpoints` references** — that doc was deleted in a prior commit, but the foundation-models index (toctree + bullet) and the `tutorials-examples` HTML list still linked to it. Removed; the content now lives in the antibody embedding walkthrough.
- **Orphaned page** — `web-app/opmodels/protein-language-models-embeddings.rst` existed but wasn't in any toctree (Sphinx `toc.not_included` warning). Added it to the opmodels toctree + bullet list.
- **Stale anchor** — the PoET `sampling parameters` links pointed at `#prompt-sampling-definitions`, which matches no section. Repointed to the real `#prompt-sampling-parameters` section in `generate-sequences`, `rank-sequences`, and `substitution-analysis`.

## Notes

- Pure docs-link hygiene; no content or API changes.
- Verified each of the three no longer appears in the Sphinx build output.
- This does **not** attempt the full strict-build (`-W`) cleanup — the build still carries other pre-existing warnings (notebook cross-links, RST cosmetics, and some upstream client docstring issues) that are out of scope here.