### PR TITLE
chore: enable -W strict sphinx build gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,9 @@ channels = ["conda-forge"]
 platforms = ["linux-64", "osx-arm64"]
 
 [tool.pixi.tasks]
-build = "sphinx-build source build"
+# -W promotes warnings to errors so doc/client-API drift fails the build;
+# --keep-going still reports every warning in one pass.
+build = "sphinx-build -W --keep-going source build"
 
 [tool.pixi.feature.dev.tasks]
 # install dev version of the client

--- a/source/python-api/api-reference/embedding.rst
+++ b/source/python-api/api-reference/embedding.rst
@@ -29,10 +29,6 @@ Models
    :inherited-members:
    :exclude-members: create, get_model
 
-.. autoclass:: openprotein.embeddings.AbLang2Model
-   :members:
-   :inherited-members:
-
 .. autoclass:: openprotein.embeddings.OpenProteinModel
    :members:
    :inherited-members:
@@ -90,7 +86,7 @@ Results
    :members:
    :inherited-members:
 
-.. autoclass:: openprotein.embeddings.EmbeddingsScoreSingleSiteFuture
+.. autoclass:: openprotein.embeddings.future.EmbeddingsScoreSingleSiteFuture
    :members:
    :inherited-members:
 

--- a/source/python-api/structure-generation/Using_RFdiffusion.ipynb
+++ b/source/python-api/structure-generation/Using_RFdiffusion.ipynb
@@ -1163,18 +1163,7 @@
    "cell_type": "markdown",
    "id": "c369740f-b331-4042-b09e-614e98a637e3",
    "metadata": {},
-   "source": [
-    "### Inpainting\n",
-    "\n",
-    "`inpaint_seq` lets you hide the amino acid identities of specific residues\n",
-    "in your input structure. RFdiffusion will then fill in these residues during \n",
-    "design, choosing sequences that fit the new structural context.\n",
-    "\n",
-    "For example, if you’re fusing two proteins, residues that were originally\n",
-    "on the surface (often polar) might end up buried in the core. Instead of\n",
-    "manually mutating them to hydrophobic residues, you can mask them with\n",
-    "inpaint_seq so RFdiffusion can decide on the best replacements automatically."
-   ]
+   "source": "## Inpainting\n\n`inpaint_seq` lets you hide the amino acid identities of specific residues\nin your input structure. RFdiffusion will then fill in these residues during \ndesign, choosing sequences that fit the new structural context.\n\nFor example, if you’re fusing two proteins, residues that were originally\non the surface (often polar) might end up buried in the core. Instead of\nmanually mutating them to hydrophobic residues, you can mask them with\ninpaint_seq so RFdiffusion can decide on the best replacements automatically."
   },
   {
    "cell_type": "code",

--- a/source/walkthroughs/Nanobody_binder_design_with_BoltzGen.ipynb
+++ b/source/walkthroughs/Nanobody_binder_design_with_BoltzGen.ipynb
@@ -1579,31 +1579,7 @@
    "cell_type": "markdown",
    "id": "36285719",
    "metadata": {},
-   "source": [
-    "# Conclusion\n",
-    "\n",
-    "In this walkthrough, we've demonstrated how to design nanobody binders for a target of\n",
-    "interest using BoltzGen and ProteinMPNN. We validated the designs using in-silico metrics and visualized them to ensure\n",
-    "their viability. The top-ranked designs from this workflow can be:\n",
-    "\n",
-    "1. Expressed and purified for experimental validation\n",
-    "2. Tested for binding affinity\n",
-    "3. Further optimized through additional rounds of design, for example, with\n",
-    "   [OpenProtein.AI's property regression models](../python-api/property-regression-models/index.rst).\n",
-    "\n",
-    "### Other resources\n",
-    "\n",
-    "Read more about our binder design workflows and other de novo design tools here:\n",
-    "- [Designing miniprotein binders with RFdiffusion](./Protein_protein_binder_design_with_RFdiffusion.ipynb)\n",
-    "- [Inverse folding for protein redesign](./PoET-2_inverse_folding.ipynb)\n",
-    "- [Antibody lead optimization](./antibody-engineering.ipynb)\n",
-    "\n",
-    "or see the detailed API references\n",
-    "- [BoltzGen](../python-api/api-reference/models.rst#boltzgen)\n",
-    "- [ProteinMPNN](../python-api/api-reference/models.rst#proteinmpnn)\n",
-    "- [Boltz-2](../python-api/api-reference/fold.rst#openprotein.fold.Boltz2Model)\n",
-    "- [PoET-2](../python-api/api-reference/embedding.rst#openprotein.embeddings.PoET2Model)"
-   ]
+   "source": "# Conclusion\n\nIn this walkthrough, we've demonstrated how to design nanobody binders for a target of\ninterest using BoltzGen and ProteinMPNN. We validated the designs using in-silico metrics and visualized them to ensure\ntheir viability. The top-ranked designs from this workflow can be:\n\n1. Expressed and purified for experimental validation\n2. Tested for binding affinity\n3. Further optimized through additional rounds of design, for example, with\n   [OpenProtein.AI's property regression models](../python-api/property-regression-models/index.rst).\n\n## Other resources\n\nRead more about our binder design workflows and other de novo design tools here:\n- [Designing miniprotein binders with RFdiffusion](./Protein_protein_binder_design_with_RFdiffusion.ipynb)\n- [Inverse folding for protein redesign](./PoET-2_inverse_folding.ipynb)\n- [Antibody lead optimization](./antibody-engineering.ipynb)\n\nor see the detailed API references\n- [BoltzGen](../python-api/api-reference/models.rst#boltzgen)\n- [ProteinMPNN](../python-api/api-reference/models.rst#proteinmpnn)\n- [Boltz-2](../python-api/api-reference/fold.rst#openprotein.fold.Boltz2Model)\n- [PoET-2](../python-api/api-reference/embedding.rst#openprotein.embeddings.PoET2Model)"
   }
  ],
  "metadata": {

--- a/source/walkthroughs/Protein_protein_binder_design_with_RFdiffusion.ipynb
+++ b/source/walkthroughs/Protein_protein_binder_design_with_RFdiffusion.ipynb
@@ -2088,29 +2088,7 @@
    "cell_type": "markdown",
    "id": "12f4bcb3-5512-41cb-92fb-4e44323e1155",
    "metadata": {},
-   "source": [
-    "# Conclusion\n",
-    "\n",
-    "In this tutorial, we've demonstrated how to design novel binders for a target of\n",
-    "interest. We validated the designs using in-silico metrics and visualized them to ensure\n",
-    "their viability. The top-ranked designs from this workflow can be:\n",
-    "\n",
-    "1. Expressed and purified for experimental validation\n",
-    "2. Tested for binding affinity\n",
-    "3. Further optimized through additional rounds of design, for example, with\n",
-    "   [OpenProtein.AI's property regression models](../python-api/property-regression-models/index.rst).\n",
-    "\n",
-    "### Other resources\n",
-    "\n",
-    "Read more about our binder design workflows and other de novo design tools here:\n",
-    "- [Designing de novo nanobody binders with BoltzGen and ProteinMPNN](./Nanobody_binder_design_with_BoltzGen.ipynb)\n",
-    "- [Inverse folding for protein redesign](./PoET-2_inverse_folding.ipynb)\n",
-    "\n",
-    "or see the detailed API references\n",
-    "- [RFdiffusion](../python-api/api-reference/models.rst#rfdiffusion)\n",
-    "- [ProteinMPNN](../python-api/api-reference/models.rst#proteinmpnn)\n",
-    "- [Boltz-2](../python-api/api-reference/fold.rst#openprotein.fold.Boltz2Model)"
-   ]
+   "source": "# Conclusion\n\nIn this tutorial, we've demonstrated how to design novel binders for a target of\ninterest. We validated the designs using in-silico metrics and visualized them to ensure\ntheir viability. The top-ranked designs from this workflow can be:\n\n1. Expressed and purified for experimental validation\n2. Tested for binding affinity\n3. Further optimized through additional rounds of design, for example, with\n   [OpenProtein.AI's property regression models](../python-api/property-regression-models/index.rst).\n\n## Other resources\n\nRead more about our binder design workflows and other de novo design tools here:\n- [Designing de novo nanobody binders with BoltzGen and ProteinMPNN](./Nanobody_binder_design_with_BoltzGen.ipynb)\n- [Inverse folding for protein redesign](./PoET-2_inverse_folding.ipynb)\n\nor see the detailed API references\n- [RFdiffusion](../python-api/api-reference/models.rst#rfdiffusion)\n- [ProteinMPNN](../python-api/api-reference/models.rst#proteinmpnn)\n- [Boltz-2](../python-api/api-reference/fold.rst#openprotein.fold.Boltz2Model)"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## What
Turns the doc build strict: `sphinx-build -W --keep-going`. Warnings become errors so doc-link rot and docs/client-API drift fail the build instead of silently shipping (e.g. an empty autodoc stub for a missing class).