### PR TITLE
docs: add new gp kernels to predictor rest api spec

### DIFF
--- a/source/_static/js/predictorSpec.js
+++ b/source/_static/js/predictorSpec.js
@@ -1450,7 +1450,15 @@ const predictorSpec = {
           type: {
             type: "string",
             description: "Type of kernel to use with GP.",
-            enum: ["linear", "rbf", "matern21", "matern32"],
+            enum: [
+              "linear",
+              "rbf",
+              "matern12",
+              "matern32",
+              "matern52",
+              "periodic",
+              "rational_quadratic",
+            ],
             example: "rbf",
           },
           multitask: {
@@ -1458,6 +1466,20 @@ const predictorSpec = {
             description: "Whether or not to train GP as multitask.",
             example: true,
             default: false,
+          },
+          period: {
+            type: "number",
+            format: "double",
+            description:
+              "Period length for the periodic kernel. Only valid when type is periodic.",
+            example: 1,
+          },
+          alpha: {
+            type: "number",
+            format: "double",
+            description:
+              "Scale-mixture parameter for the rational_quadratic kernel; must be > 0. Only valid when type is rational_quadratic.",
+            example: 1,
           },
         },
       },


### PR DESCRIPTION
## Summary
Update the predictor REST API docs to reflect the new GP kernels. The docs site
renders the predictor API via Swagger UI from the checked-in OpenAPI bundle
`source/_static/js/predictorSpec.js`; this regenerates the `Kernel` schema in
that bundle to match the openprotein-api source.

## Changes
- `Kernel.type` enum: rename `matern21` -> `matern12`; add `matern52`,
  `periodic`, `rational_quadratic`.
- Add the `period` (periodic) and `alpha` (rational_quadratic) kernel
  hyperparameters.

Surgical edit to the `Kernel` block only (matching the file's existing style),
rather than a full re-bundle, to keep the diff reviewable. Verified by serving
the site locally (`sphinx-autobuild`) and confirming the predictor page renders
the updated schema.

## Merge order
Mirrors the OpenAPI source change in **OpenProteinAI/openprotein-api#15**
(`feat: add matern52/periodic/rational_quadratic to the Kernel schema`). Merge
**after** that PR, since this reflects spec content that lands there.
